### PR TITLE
Silence GitGuardian dev-cred false positive + fix dead site URL

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,21 @@
+# GitGuardian configuration
+# https://docs.gitguardian.com/ggshield-docs/reference/configuration
+#
+# Silences false positives on LOCAL-DEVELOPMENT placeholder credentials.
+# These are not real secrets: they appear only in example/dev/CI config, use
+# the fixed literal value below, and connect to localhost.
+version: 2
+
+secret:
+  # Ignore this exact placeholder wherever it appears.
+  ignored_matches:
+    - name: "Local dev Postgres placeholder credentials (not a real secret)"
+      match: "postgresql://openscript:openscript@localhost:5432/openscript"
+
+  # Files that only ever contain dev/example/CI placeholders.
+  ignored_paths:
+    - "apps/web/.env.example"
+    - "apps/web/Dockerfile"
+    - "docker-compose.yml"
+    - ".github/workflows/bun-ci.yml"
+    - "**/CONTRIBUTING.md"

--- a/apps/web/src/site/brand.ts
+++ b/apps/web/src/site/brand.ts
@@ -1,4 +1,7 @@
-export const SITE_URL = "https://openscript.app";
+// Public origin where the app is served. openscript.app is not registered yet,
+// so this points at the live Vercel domain. (The editor itself lives under /app
+// via BASE_PATH below.)
+export const SITE_URL = "https://tryopenscript.vercel.app";
 
 // Keep in sync with `basePath` in next.config.ts. The editor ships as a
 // Next.js Multi-Zones "zone" mounted under /app, so its API routes and the


### PR DESCRIPTION
- Adds `.gitguardian.yaml` to ignore the local-dev Postgres placeholder (`postgresql://openscript:openscript@localhost:5432/openscript`) and the example/dev/CI files that carry it. Not a real secret — localhost dev default.
- `SITE_URL` → `https://tryopenscript.vercel.app` since `openscript.app` isn't registered; keeps canonical/OG metadata pointing at the live domain.