### PR TITLE
feat(transcript): Clear button + actually delete persisted transcript

### DIFF
--- a/apps/web/src/core/managers/__tests__/transcript-store.test.ts
+++ b/apps/web/src/core/managers/__tests__/transcript-store.test.ts
@@ -1,12 +1,28 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, mock } from "bun:test";
 import type { EditorCore } from "@/core";
 import type { TranscriptDocument } from "@/transcript-editor/types";
+
+const deleteTranscript = mock(() => Promise.resolve());
+const saveTranscript = mock(() => Promise.resolve());
+mock.module("@/services/storage/service", () => ({
+	storageService: { deleteTranscript, saveTranscript },
+}));
+
 import { TranscriptStore } from "../transcript-store";
 
 // persist:false keeps the store from touching storageService / the editor, so a
 // bare cast is safe here — the store only dereferences the editor when persisting.
 function makeStore(): TranscriptStore {
 	return new TranscriptStore({} as unknown as EditorCore);
+}
+
+function makeStoreWithProject(projectId: string | null): TranscriptStore {
+	return new TranscriptStore({
+		project: {
+			getActiveOrNull: () =>
+				projectId ? { metadata: { id: projectId } } : null,
+		},
+	} as unknown as EditorCore);
 }
 
 const doc: TranscriptDocument = { segments: [], deletedRanges: [] };
@@ -31,5 +47,27 @@ describe("TranscriptStore", () => {
 		store.setDoc(null, { persist: false });
 		expect(calls).toBe(1);
 		expect(store.getDoc()).toBeNull();
+	});
+
+	test("clearDoc nulls the document and notifies", () => {
+		const store = makeStoreWithProject(null);
+		let calls = 0;
+		store.subscribe(() => {
+			calls++;
+		});
+		store.setDoc(doc, { persist: false });
+		expect(store.getDoc()).toBe(doc);
+		store.clearDoc();
+		expect(store.getDoc()).toBeNull();
+		expect(calls).toBe(2); // setDoc + clearDoc
+	});
+
+	test("clearDoc deletes the persisted transcript for the active project", () => {
+		deleteTranscript.mockClear();
+		const store = makeStoreWithProject("proj-1");
+		store.setDoc(doc, { persist: false });
+		store.clearDoc();
+		expect(deleteTranscript).toHaveBeenCalledTimes(1);
+		expect(deleteTranscript).toHaveBeenCalledWith({ projectId: "proj-1" });
 	});
 });

--- a/apps/web/src/core/managers/transcript-store.ts
+++ b/apps/web/src/core/managers/transcript-store.ts
@@ -41,6 +41,20 @@ export class TranscriptStore {
 		this.notify();
 	}
 
+	/**
+	 * Discard the active transcript AND remove its persisted copy, so a refresh
+	 * doesn't reload it. (setDoc(null) only clears memory — it deliberately never
+	 * touches storage, since undo/redo round-trips through it.)
+	 */
+	clearDoc(): void {
+		this.doc = null;
+		const projectId = this.editor.project.getActiveOrNull()?.metadata.id;
+		if (projectId) {
+			void storageService.deleteTranscript({ projectId });
+		}
+		this.notify();
+	}
+
 	subscribe(listener: () => void): () => void {
 		this.listeners.add(listener);
 		return () => this.listeners.delete(listener);

--- a/apps/web/src/transcript-editor/transcript-panel.tsx
+++ b/apps/web/src/transcript-editor/transcript-panel.tsx
@@ -468,6 +468,23 @@ export function TranscriptPanel() {
 		}
 	}, [activeWordId]);
 
+	const clearTranscript = useCallback(() => {
+		if (
+			!window.confirm(
+				"Clear this transcript? You can regenerate it, but any transcript text edits will be lost.",
+			)
+		) {
+			return;
+		}
+		editor.transcript.clearDoc();
+		setStatus({ kind: "idle" });
+		setSelection(new Set());
+		setLastSelectedId(null);
+		setSearchOpen(false);
+		setSearchQuery("");
+		setEditingWordId(null);
+	}, [editor]);
+
 	return (
 		<div className="panel bg-background flex h-full flex-col overflow-hidden rounded-sm border">
 			<div className="border-b px-3 py-2 flex flex-wrap items-center justify-between gap-2">
@@ -495,6 +512,14 @@ export function TranscriptPanel() {
 								Remove {fillerCount} filler{fillerCount === 1 ? "" : "s"}
 							</Button>
 						)}
+						<Button
+							size="sm"
+							variant="text"
+							onClick={clearTranscript}
+							title="Clear the transcript and start over (lets you pick a model and re-transcribe)"
+						>
+							Clear
+						</Button>
 						<Button
 							size="sm"
 							variant="destructive-foreground"


### PR DESCRIPTION
Fixes: removing the video left the transcript behind, and there was no way to re-pick a model.

**Cause:** `setDoc(null)` only clears the in-memory doc — it never deletes the persisted copy (deliberately, since undo/redo round-trips through `setDoc`). So on refresh the stored transcript reloaded, and while a doc exists the model picker (`EmptyState`) stays hidden — no way to re-transcribe.

**Fix:**
- `TranscriptStore.clearDoc()` — nulls the doc **and** deletes the persisted transcript for the active project (`deleteTranscript({ projectId })`).
- Toolbar **"Clear"** button (confirms first) → resets status to `idle`, clears selection/search → returns to the model picker + Generate.
- Tests: `clearDoc` nulls+notifies, and deletes the persisted transcript (4 store tests, mocked storage).

**Verification:** `tsc` clean; 42 tests pass.